### PR TITLE
Add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @HackYourFuture-CPH/curriculum-crew


### PR DESCRIPTION
... so that the Curriculum Crew is pinged on all pull request reviews.

Furthermore, after merging this, we could choose to enable the "Require review from Code Owners" repo setting.
