### PR TITLE
Add How to contribute section with linter and editor setup

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,8 @@
+{
+  "recommendations": [
+    "takumii.markdowntable",
+    "yzhang.markdown-all-in-one",
+    "streetsidesoftware.code-spell-checker",
+    "editorconfig.editorconfig"
+  ]
+}

--- a/contributing/README.md
+++ b/contributing/README.md
@@ -7,7 +7,45 @@ Write in there to introduce yourself, and a staff member will onboard you and se
 
 ## How to contribute
 
-(We will flesh these processes more as we go...)
+This project is a collection of structured README files. To maintain consistency and quality, we use a linter and suggest some recommended editor extensions.
+
+### 1. Install dependencies
+
+First, make sure you have [Node.js](https://nodejs.org/) installed.
+
+Then, install the project dependencies using:
+
+```bash
+npm ci
+```
+
+This ensures a clean and reproducible setup based on the `package-lock.json`.
+
+### 2. Set up your editor (optional but recommended)
+
+If you are using [Visual Studio Code](https://code.visualstudio.com/), we have a list of recommended extensions in `.vscode/extensions.json`. When you open the project in VSCode, it will automatically suggest installing them to improve your development experience.
+
+These extensions help with linting and maintaining the project’s standards.
+
+### 3. Make your changes
+
+Edit or create README files as needed. Follow the existing formatting and writing style.
+
+### 4. Run the linter
+
+Before committing your changes, make sure everything passes the linter.
+
+To check for linting issues:
+
+```bash
+./lint
+```
+
+To automatically fix some issues:
+
+```bash
+./lint --fix
+```
 
 ### Existing issues
 
@@ -15,9 +53,9 @@ Very briefly: check the project board "Todo" column, choose one ideally near the
 
 ### New ideas
 
-Very briefly: Create an issue on this repo, get some feedback, and we'll prioritise them together at the next meeting.
+Very briefly: Create an issue on this repo, get some feedback, and we'll prioritize them together at the next meeting.
 
-Note: You are always welcome to open issues/create PRs for new ideas, whenever you like. It's an open source project. If we are currently working together towards a project goal, then it would be most helpful to prioritise tasks for that first, though.
+Note: You are always welcome to open issues/create PRs for new ideas, whenever you like. It's an open source project. If we are currently working together towards a project goal, then it would be most helpful to prioritize tasks for that first, though.
 
 ## How permissions work
 


### PR DESCRIPTION
This adds a new **How to contribute** section to the documentation, with:

- Instructions for installing Node.js dependencies using `npm ci`
- Details on how to run the linter (`./lint` or `./lint --fix`)
- A note about recommended VSCode extensions from .vscode/extensions.json
  - **`takumii.markdowntable`**  
  Helps edit and format markdown tables more easily. Great for keeping tables aligned and readable in README files.

  - **`yzhang.markdown-all-in-one`**  
  A comprehensive markdown toolkit. Provides features like table of contents generation, shortcuts for formatting, and enhanced markdown preview.

  - **`streetsidesoftware.code-spell-checker`**  
  Adds spell checking for markdown (and code comments). Helps catch typos in documentation and maintain a polished appearance.

  - **`editorconfig.editorconfig`**  
  Reads `.editorconfig` settings to ensure consistent indentation, line endings, and other coding style rules across different editors and contributors.