### PR TITLE
New lint rule: no trailing whitespace in markdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Programme
 
-> [!WARNING]  
+> [!WARNING]
 > This repository is under construction. If you're looking for the current HYF curriculum, check out [Curriculum](https://github.com/HackYourFuture-CPH/curriculum).
 
 Documents the HYF programme, courses and modules.

--- a/support/src/parse.ts
+++ b/support/src/parse.ts
@@ -17,9 +17,21 @@ export type ParsedImage = {
 export type ParseResult = {
   readonly links: readonly ParsedLink[];
   readonly images: readonly ParsedImage[];
+  readonly trailingWhitespace: readonly SourceLocation[];
 };
 
 export const parse = (content: string): ParseResult => {
+  const trailingWhitespace: SourceLocation[] = [];
+
+  content.split(/\n/).forEach((line, index) => {
+    if (line.endsWith(" ")) {
+      trailingWhitespace.push({
+        line0: index,
+        column0: line.trimEnd().length,
+      });
+    }
+  });
+
   const parser = mit();
   const tokens = parser.parse(content, {});
 
@@ -64,5 +76,6 @@ export const parse = (content: string): ParseResult => {
   return {
     links: parsedLinks,
     images: parsedImages,
+    trailingWhitespace,
   };
 };

--- a/support/src/validateLinks.ts
+++ b/support/src/validateLinks.ts
@@ -28,10 +28,7 @@ const findAllFiles = async (): Promise<string[]> => {
 };
 
 const findMarkdownFiles = (files: string[]): string[] => {
-  const ignorePattern = /^(README|LICENSE|contributing\/)/;
-  return files.filter(
-    (f) => f.toLocaleLowerCase().endsWith(".md") && !ignorePattern.test(f),
-  );
+  return files.filter((f) => f.toLocaleLowerCase().endsWith(".md"));
 };
 
 const scanForLinks = async (filenames: string[]): Promise<ParsedFile[]> => {
@@ -70,6 +67,16 @@ const main = async () => {
   let errors = 0;
 
   for (const parsedFile of parsedFiles) {
+    for (const ws of parsedFile.trailingWhitespace) {
+      showError(
+        parsedFile.filename,
+        ws,
+        "VL003/trailing-whitespace",
+        "Trailing whitespace",
+      );
+      ++errors;
+    }
+
     for (const img of parsedFile.images) {
       if (!isExternalLink(img.src)) {
         const resolved = path.join(dirname(parsedFile.filename), img.src);


### PR DESCRIPTION
We currently have exactly one instance of this, namely in the repo top-level README; and even then, it does nothing — the doc renders exactly the same without the whitespace, as with.

This PR removes that instance, and adds a rule to `./lint` to complain on any re-appearance.
