### PR TITLE
Prefer https over http. Mark some external links as 404 / dead

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,4 +1,4 @@
-# Editor configuration, see http://editorconfig.org
+# Editor configuration, see https://editorconfig.org
 root = true
 
 [*]

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -4,4 +4,4 @@ The HackYourFuture programme is subject to CC BY NC SA copyright. This means you
 
 ![Creative Commons License ](https://github.com/user-attachments/assets/912a16ff-b11a-4dcf-9c07-7bdce3d72e64)
 
-This work is licensed under a [Creative Commons Attribution 4.0 International License](http://creativecommons.org/licenses/by-nc-sa/4.0/).
+This work is licensed under a [Creative Commons Attribution 4.0 International License](https://creativecommons.org/licenses/by-nc-sa/4.0/).

--- a/legacy/databases/lesson1/README.md
+++ b/legacy/databases/lesson1/README.md
@@ -42,7 +42,7 @@ game changer, so it’s good for you if you at least know what it is :slightly_s
 
 ## Reference Material
 
-- [TutorialsPoint MySQL Introduction](http://www.tutorialspoint.com/mysql/mysql-introduction.htm)
+- [TutorialsPoint MySQL Introduction](https://www.tutorialspoint.com/mysql/mysql-introduction.htm)
 - [w3schools tutorial (easy to find how specific commands work)](https://www.w3schools.com/sql/default.asp)
 - [Official MySQL Documentation](https://dev.mysql.com/doc/refman/8.0/en/)
 - [Official MySQL Tutorial (pretty dense)](https://dev.mysql.com/doc/refman/8.0/en/tutorial.html)

--- a/legacy/databases/lesson2/README.md
+++ b/legacy/databases/lesson2/README.md
@@ -6,9 +6,9 @@ Objective: the students should be able to build CRUD functionality using SQL sta
 
 ## Pre-Class Readings
 
-- [Falsehoods Programmers Believe About Names](http://www.kalzumeus.com/2010/06/17/falsehoods-programmers-believe-about-names/)
+- [Falsehoods Programmers Believe About Names](https://www.kalzumeus.com/2010/06/17/falsehoods-programmers-believe-about-names/)
 - [What is a Database Foreign Key](https://www.educative.io/blog/what-is-foreign-key-database)
-- [Example Entity Relationship Diagram (including associative entities)](http://users.csc.calpoly.edu/~jdalbey/308/Lectures/HOWTO-ERD.html)
+- [Example Entity Relationship Diagram (including associative entities)](https://users.csc.calpoly.edu/~jdalbey/308/Lectures/HOWTO-ERD.html)
 
 The students should watch this video before class: <https://youtu.be/9hTKUT_SZWU>
 
@@ -33,8 +33,8 @@ The students should watch this video before class: <https://youtu.be/9hTKUT_SZWU
 
 ## Reference Material
 
-- [Floating Point Inaccuracy](http://stackoverflow.com/questions/2100490/floating-point-inaccuracy-examples#2100502)
-- [TutorialsPoint MySQL Introduction](http://www.tutorialspoint.com/mysql/mysql-introduction.htm)
+- [Floating Point Inaccuracy](https://stackoverflow.com/questions/2100490/floating-point-inaccuracy-examples#2100502)
+- [TutorialsPoint MySQL Introduction](https://www.tutorialspoint.com/mysql/mysql-introduction.htm)
 - [w3schools tutorial (easy to find how specific commands work)](https://www.w3schools.com/sql/default.asp)
 - [Official MySQL Documentation](https://dev.mysql.com/doc/refman/8.0/en/)
 

--- a/legacy/databases/lesson2/preparation_flipped_classroom.md
+++ b/legacy/databases/lesson2/preparation_flipped_classroom.md
@@ -13,8 +13,8 @@ Since this is a semi flipped classroom, where you prepare the class during the w
 
 ## Readings
 
-- [Falsehoods Programmers Believe About Names](http://www.kalzumeus.com/2010/06/17/falsehoods-programmers-believe-about-names/)
-- [What is a Database Foreign Key](http://databases.about.com/cs/specificproducts/g/foreignkey.htm)
+- [Falsehoods Programmers Believe About Names](https://www.kalzumeus.com/2010/06/17/falsehoods-programmers-believe-about-names/)
+- [What is a Database Foreign Key](http://databases.about.com/cs/specificproducts/g/foreignkey.htm) <!-- http-404 -->
 
 ## Exercise before class
 

--- a/legacy/databases/lesson3/README.md
+++ b/legacy/databases/lesson3/README.md
@@ -9,7 +9,7 @@ Objective: the students should know how SQL injections happen, and how to define
 Please read the following pages that explains the ACID database model:
 
 - [ACID Properties with real life examples](https://medium.com/%40tushar.rooks/acid-properties-with-real-life-examples-b83a37667338)
-- [Why you should never use MongoDB](http://www.sarahmei.com/blog/2013/11/11/why-you-should-never-use-mongodb)
+- [Why you should never use MongoDB](http://www.sarahmei.com/blog/2013/11/11/why-you-should-never-use-mongodb) <!-- no-https -->
 
 Also the students should watch this video: <https://youtu.be/HSt4nlUIF-A>
 

--- a/legacy/databases/lesson3/preparation_flipped_classroom.md
+++ b/legacy/databases/lesson3/preparation_flipped_classroom.md
@@ -18,7 +18,7 @@ And if you want to experiment more with mongoDB commands, you can check [these t
 ## Readings
 
 - [ACID Properties with real life examples](https://medium.com/%40tushar.rooks/acid-properties-with-real-life-examples-b83a37667338)
-- [Why you should never use MongoDB](http://www.sarahmei.com/blog/2013/11/11/why-you-should-never-use-mongodb)
+- [Why you should never use MongoDB](http://www.sarahmei.com/blog/2013/11/11/why-you-should-never-use-mongodb) <!-- no-https -->
 
 ## Exercise before class
 

--- a/legacy/git/git1/resources.md
+++ b/legacy/git/git1/resources.md
@@ -4,8 +4,8 @@ Here are a few resources that might be useful:
 
 - Git and Github in Plain English, super nice to understand the concepts: <https://blog.red-badger.com/2016/11/29/gitgithub-in-plain-english>
 - a quick overview of git: <https://guides.github.com/introduction/git-handbook/>;
-- a beginner's tutorial: <http://ryanflorence.com/git-for-beginners/>;
-- a simple git guide: <http://rogerdudler.github.io/git-guide/>;
+- a beginner's tutorial: <http://ryanflorence.com/git-for-beginners/>; <!-- http-404 -->
+- a simple git guide: <https://rogerdudler.github.io/git-guide/>;
 - an interactive tutorial: <https://learngitbranching.js.org/>. The relevant parts for you are in the "Main" section, introduction sequence, parts 1-3, and in the "Remote" section, the full "Push & Pull" sequence. Feel free to do the other parts if you want :). You can also go to <https://learngitbranching.js.org/?NODEMO> if you want to just play around;
 - the Pro Git book: <https://git-scm.com/om/book/en/v2> , you'll find pretty much everything about git there, but might be tedious :);
 - a list of some graphical interfaces for git: <https://git-scm.com/downloads/guis>;

--- a/legacy/javascript/README.md
+++ b/legacy/javascript/README.md
@@ -31,4 +31,4 @@ A web app with external data source using at least one API
 A good understanding of all the above mentioned topics. Want to check your Knowledge?
 Go through the [JavaScript Fundamentals readme](./fundamentals) and research/ask for help [(Slack!)](https://hackyourfuture-cph.slack.com) with the concepts that are not entirely clear.
 
-Helpful resource: <http://jsbooks.revolunet.com/> (here you can find tons of free JavaScript books online)
+Helpful resource: <https://jsbooks.revolunet.com/> (here you can find tons of free JavaScript books online)

--- a/legacy/javascript/fundamentals/bug-challenge-es6/bug-challenge.js
+++ b/legacy/javascript/fundamentals/bug-challenge-es6/bug-challenge.js
@@ -97,7 +97,7 @@ export default class BugChallenge {
     }
 
     fetch({
-      url: "http://www.example.com",
+      url: "https://www.example.com",
       useCaching: false,
     });
   }

--- a/legacy/javascript/javascript1/week1/README.md
+++ b/legacy/javascript/javascript1/week1/README.md
@@ -25,7 +25,7 @@ A "variable" is a place where you can store information, such as a string, or a 
 > Think of variables names like **labels** on boxes, while the value of the variable are the **contents** of the box - you could change the contents of a box and leave the label intact, the contents of the boxes can have different types, the boxes should have good labels (a box of books being labeled pens would be very confusing),
 >
 > ![Variables are like boxes](./assets/box.png)
-> Photo from [Khan Academy](http://cs-blog.khanacademy.org/2013/09/teaching-variables-analogies-and.html)
+> Photo from [Khan Academy](https://cs-blog.khanacademy.org/2013/09/teaching-variables-analogies-and.html)
 
 ### Variable declaration
 
@@ -41,7 +41,7 @@ const bar;
 
 - read about [let](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/let)
 - read about [const](https://developer.mozilla.org/nl/docs/Web/JavaScript/Reference/Statements/const)
-- [let vs const](http://wesbos.com/let-vs-const/)
+- [let vs const](https://wesbos.com/let-vs-const/)
 
 Here, we say: "declare variable x and initialize it with the integer (number) 5".
 

--- a/legacy/javascript/javascript1/week2/preparation.md
+++ b/legacy/javascript/javascript1/week2/preparation.md
@@ -1,8 +1,8 @@
 # Preparation for the second lecture
 
-- [Functions](http://javascript.info/function-basics) (15 min)
-- [Conditions](http://javascript.info/ifelse) (10 min)
-- Read from [For loops](http://javascript.info/while-for#the-for-loop) to and with [for loops continue](http://javascript.info/while-for#continue) (10 min)
+- [Functions](https://javascript.info/function-basics) (15 min)
+- [Conditions](https://javascript.info/ifelse) (10 min)
+- Read from [For loops](https://javascript.info/while-for#the-for-loop) to and with [for loops continue](https://javascript.info/while-for#continue) (10 min)
 
 ![Cosy rain](https://media.giphy.com/media/k28n1OPefBEeQ/giphy.gif)
 

--- a/legacy/javascript/javascript1/week3/README.md
+++ b/legacy/javascript/javascript1/week3/README.md
@@ -47,7 +47,7 @@ Remember that there is a very big difference between `obj[name]` and `obj["name"
 When a function is called it is pushed to the call stack.
 When a function is finished the function gets shifted from the call stack.
 
-Visualize here: <http://latentflip.com/loupe>
+Visualize here: <http://latentflip.com/loupe> <!-- no-https -->
 
 ```js
 function pickUpKids() {

--- a/legacy/javascript/javascript1/week3/homework.md
+++ b/legacy/javascript/javascript1/week3/homework.md
@@ -86,7 +86,7 @@ const seriesDurations = [
 
 How much time of my life have i been watching series on tv? Lets find out! Calculate **how much time a tv series** have taken as a **percentage of an average lifespan** of 80 years.
 
-Firstly change the `seriesDurations` array found above to include your favorite series. Find the duration of a series here: <http://tiii.me/>
+Firstly change the `seriesDurations` array found above to include your favorite series. Find the duration of a series here: <https://tiii.me/>
 
 Create a function that logs out the following text using the `seriesDurations` array:
 

--- a/legacy/javascript/javascript1/week3/lesson-plan.md
+++ b/legacy/javascript/javascript1/week3/lesson-plan.md
@@ -31,7 +31,7 @@ If you find anything that could be improved then please create a pull request! W
 - [Codewar exercises](#codewar-exercises)
 - Call stack
   - Used for figuring code flow in js! Where does my function go when it is done here.
-  - <http://latentflip.com/loupe>
+  - <http://latentflip.com/loupe> <!-- no-https -->
   - [Code inspiration](#inspiration-call-stack)
   - [Exercise](#exercise-call-stack)
 

--- a/legacy/javascript/javascript1/week3/preparation.md
+++ b/legacy/javascript/javascript1/week3/preparation.md
@@ -1,7 +1,7 @@
 # Preparation
 
-- [Array](http://javascript.info/array) up until and with [internals](http://javascript.info/array#internals) (10 min)
-- [Objects](http://javascript.info/object) (15 min)
+- [Array](https://javascript.info/array) up until and with [internals](https://javascript.info/array#internals) (10 min)
+- [Objects](https://javascript.info/object) (15 min)
 
 _Please go through the material and come to class prepared!_
 

--- a/legacy/javascript/javascript2/week1/README.md
+++ b/legacy/javascript/javascript2/week1/README.md
@@ -113,7 +113,7 @@ Single line comments at end of the line:
 const x = 5; // Declare x, give it the value of 5
 ```
 
-Writing js documentation: [JSDoc](http://usejsdoc.org/)
+Writing js documentation: [JSDoc](https://usejsdoc.org/) <!-- http-trash -->
 
 ### When to comment?
 

--- a/legacy/javascript/javascript2/week1/preparation.md
+++ b/legacy/javascript/javascript2/week1/preparation.md
@@ -1,7 +1,7 @@
 # Preparation
 
 - [Basic DOM manipulations (img src, innerHTML)](https://github.com/HackYourFuture/fundamentals/blob/master/fundamentals/DOM_manipulation.md) (5 min)
-- [Code Degugging Using the Browser](http://javascript.info/debugging-chrome) (5 min)
+- [Code Degugging Using the Browser](https://javascript.info/debugging-chrome) (5 min)
 - [Code commenting](https://github.com/HackYourFuture/fundamentals/blob/master/fundamentals/code_commenting.md) (2 min)
 - [Attaching an event](https://www.w3schools.com/jsref/met_element_addeventlistener.asp) (5 min)
 

--- a/legacy/javascript/javascript2/week3/README.md
+++ b/legacy/javascript/javascript2/week3/README.md
@@ -82,7 +82,7 @@ First setTimeout is added to the call stack. The call stack hands it over to the
 
 When the timer is expired it sends the callback of our setTimeout function to the eventloop. The eventloop then works like this: if the call stack is empty it will take the first thing in the event loop and add it to the call stack. When it is added to the call stack it is javascript call stack business as usual. Call the function and pop it from the call stack.
 
-This is perfectly visualised here: <http://latentflip.com/loupe>
+This is perfectly visualised here: <http://latentflip.com/loupe> <!-- no-https -->
 
 ### So why do we have async code in js?
 

--- a/legacy/javascript/javascript2/week3/preparation.md
+++ b/legacy/javascript/javascript2/week3/preparation.md
@@ -1,7 +1,7 @@
 # Preparation
 
 - Callback functions: <https://www.youtube.com/watch?v=pTbSfCT42_M> (15 min)
-- Read about Asynchronous vs. Synchronous programming: <http://www.hongkiat.com/blog/synchronous-asynchronous-javascript/> (10 min)
+- Read about Asynchronous vs. Synchronous programming: <https://www.hongkiat.com/blog/synchronous-asynchronous-javascript/> (10 min)
 
 _Please go through the material and come to class prepared!_
 

--- a/legacy/javascript/javascript3/week1/lesson-plan.md
+++ b/legacy/javascript/javascript3/week1/lesson-plan.md
@@ -112,7 +112,7 @@ Web API's are like that, but just for getting data from a server.
 
 There are some funny apis to play with:
 
-- <http://deckofcardsapi.com/>
+- <https://deckofcardsapi.com/>
 - <https://github.com/toddmotto/public-apis>
 
 This incredibly unique service generates true random numbers by measuring quantum fluctuations of a vacuum in real-time!
@@ -148,7 +148,7 @@ Think about what what type the data should be saved as!
 
 ## Astronauts in space
 
-Use [this api](http://api.open-notify.org/astros.json) to fetch how many astronauts are currently in spaces.
+Use [this api](http://api.open-notify.org/astros.json) <!-- no-https--> to fetch how many astronauts are currently in spaces.
 
 Add the following text to the DOM, using the data about astronauts:
 

--- a/legacy/nodejs/week1/preparation.md
+++ b/legacy/nodejs/week1/preparation.md
@@ -59,7 +59,7 @@ You can also feed node files to evaluate and this is where node becomes such a p
 
 ### Creating an NPM project with a script that starts the application
 
-<http://ajmalsiddiqui.me/blog/introduction-to-npm-scripts/>
+<https://ajmalsiddiqui.me/blog/introduction-to-npm-scripts/>
 
 ### As a Webserver
 

--- a/legacy/nodejs/week2/README.md
+++ b/legacy/nodejs/week2/README.md
@@ -41,7 +41,7 @@ If you open that URL in the browser you will see “hello world” (without any 
 This is a very basic example of an express application. There many parameters to tweak and cases to take into consideration.
 One of the first things we’d like to do in a typical Express application is to not return strings or HTML, but instead use JSON as the transport encoding format. Meaning we accept JSON in requests and we can respond with JSON formatted data.
 
-There are a few good extensions or middleware that is easy to plug into express and allows us to tweak and change some of the parts of the webserver. Some of these middleware extensions include body-parser, compression, cors, errorhandler - find the full list here: <http://expressjs.com/en/resources/middleware.html>.
+There are a few good extensions or middleware that is easy to plug into express and allows us to tweak and change some of the parts of the webserver. Some of these middleware extensions include body-parser, compression, cors, errorhandler - find the full list here: <https://expressjs.com/en/resources/middleware.html>.
 
 ## More resources
 

--- a/legacy/nodejs/week2/exercises/03-api.md
+++ b/legacy/nodejs/week2/exercises/03-api.md
@@ -6,7 +6,7 @@ The end goal of the exercise is to implement the following routes:
 - `GET /api/snippets` to get a list of snippets
 - `GET /api/snippets/:id` to get a single snippet
 
-We will create the snippet routes in a different file, `api/snippets.js`, which will export an [Express Router](http://expressjs.com/en/4x/api.html#router).
+We will create the snippet routes in a different file, `api/snippets.js`, which will export an [Express Router](https://expressjs.com/en/4x/api.html#router).
 
 That will look something like this:
 

--- a/legacy/nodejs/week2/homework/README.md
+++ b/legacy/nodejs/week2/homework/README.md
@@ -143,7 +143,7 @@ For this week's homework, we will add two categories of routes: meals and reserv
 - The reservation routes will live in `/api/src/routers/reservations.js`
 
 This means that we will end up having two Routers: a meals router and a reservations router.
-You can read more about Express Routers [here](http://expressjs.com/en/4x/api.html#router).
+You can read more about Express Routers [here](https://expressjs.com/en/4x/api.html#router).
 
 You can reference the file `/api/src/routers/nested.js` for an example, and see how it is used in `/api/src/index.js`.
 


### PR DESCRIPTION
I've gone through the links that were `http://` (not `https://`) and changed them to https where that works, else marked them as `<!-- no-https -->`. Also, some I have annotated with other things.

However: I haven't gone through the 750+ `https` links that we have, and I don't fancy doing that by hand; which suggests that either we just occasionally fix bad links that we discover, and/or we need something entirely new to check links in an automated fashion — which this PR definitely does not provide.