### PR TITLE
More accurate lint source location data; highlight/fail on deprecated terms

### DIFF
--- a/support/src/parse.ts
+++ b/support/src/parse.ts
@@ -1,6 +1,11 @@
 import mit from "markdown-it";
 import type { Token } from "markdown-it/index.js";
-import { sourceLocationOf, type SourceLocation } from "./sourceLocation.js";
+import {
+  markUpContent,
+  sourceLocationOf,
+  unMarkUpContent,
+  type SourceLocation,
+} from "./sourceLocation.js";
 
 export type ParsedLink = {
   readonly target: string;
@@ -33,7 +38,7 @@ export const parse = (content: string): ParseResult => {
   });
 
   const parser = mit();
-  const tokens = parser.parse(content, {});
+  const tokens = parser.parse(markUpContent(content), {});
 
   const parsedLinks: ParsedLink[] = [];
   const parsedImages: ParsedImage[] = [];
@@ -46,24 +51,24 @@ export const parse = (content: string): ParseResult => {
         );
 
         if (indexOfNextClose > index) {
-          const target = token.attrGet("href") as string;
+          const markedUpTarget = token.attrGet("href") as string;
           parsedLinks.push({
-            target,
+            target: unMarkUpContent(markedUpTarget),
             content: tokens
               .slice(index + 1, indexOfNextClose)
-              .map((t) => t.content)
+              .map((t) => unMarkUpContent(t.content))
               .join(""),
-            sourceLocation: sourceLocationOf(`(${target})`, content),
+            sourceLocation: sourceLocationOf(markedUpTarget),
           });
         }
       }
 
       if (token.type === "image") {
-        const src = token.attrGet("src") as string;
+        const markedUpSrc = token.attrGet("src") as string;
         parsedImages.push({
-          src,
-          alt: token.content,
-          sourceLocation: sourceLocationOf(`(${src})`, content),
+          src: unMarkUpContent(markedUpSrc),
+          alt: unMarkUpContent(token.content),
+          sourceLocation: sourceLocationOf(markedUpSrc),
         });
       }
 

--- a/support/src/validateLinks.ts
+++ b/support/src/validateLinks.ts
@@ -77,6 +77,16 @@ const main = async () => {
       ++errors;
     }
 
+    for (const found of parsedFile.deprecatedTerm) {
+      showError(
+        parsedFile.filename,
+        found.sourceLocation,
+        "VL004/deprecated-term",
+        `Deprecated term '${found.term}'`,
+      );
+      if (found.term !== "class") ++errors;
+    }
+
     for (const img of parsedFile.images) {
       if (!isExternalLink(img.src)) {
         const resolved = path.join(dirname(parsedFile.filename), img.src);


### PR DESCRIPTION
Reports deprecated terms in markdown _text_ (not code blocks, and not link targets), with nice accurate source code locations :-) 

Matches on `class` are not "fatal", i.e. not sufficient to fail the build, because there will be so many false positives.

I have no idea if all this is even slightly useful.

