### PR TITLE
Readme navigation

### DIFF
--- a/courses/README.md
+++ b/courses/README.md
@@ -5,12 +5,12 @@ Our programme is split into multiple phases. In the specialisms phase, there are
 > [!IMPORTANT]
 > This repository lists all of the courses that we have developed. We do not always run every course listed below. To see which courses are active and open for applications, see our website [hackyourfuture.dk](https://hackyourfuture.dk).
 
-## [Pre-Course](./pre-course/)
+## [Pre-Course](./pre-course/README.md)
 
-## [Foundation](./foundation/)
+## [Foundation](./foundation/README.md)
 
 ## Specialisms
 
-### [Frontend](./frontend/)
+### [Frontend](./frontend/README.md)
 
-### [Backend](./backend/)
+### [Backend](./backend/README.md)

--- a/courses/backend/README.md
+++ b/courses/backend/README.md
@@ -4,10 +4,10 @@ This specialism course is focused on setting you up to land a Backend Developer 
 
 ## Modules
 
-| Name                                                                            | Weeks           |
-| ------------------------------------------------------------------------------- | --------------- |
+| Name                                                                                     | Weeks           |
+| ---------------------------------------------------------------------------------------- | --------------- |
 | [Collaboration via GitHub](../../shared-modules/collaboration-via-github/README.md)      | 1               |
-| [Using AI in Development](../../shared-modules/using-ai-in-development/README.md)         | 1               |
+| [Using AI in Development](../../shared-modules/using-ai-in-development/README.md)        | 1               |
 | [Advanced JavaScript](./advanced-javascript/README.md)                                   | 4               |
 | [Databases](./databases/README.md)                                                       | 2               |
 | [Node.js](node/README.md)                                                                | 2               |

--- a/courses/backend/README.md
+++ b/courses/backend/README.md
@@ -6,13 +6,13 @@ This specialism course is focused on setting you up to land a Backend Developer 
 
 | Name                                                                            | Weeks           |
 | ------------------------------------------------------------------------------- | --------------- |
-| [Collaboration via GitHub](../../shared-modules/collaboration-via-github/)      | 1               |
-| [Using AI in Development](../../shared-modules/using-ai-in-development)         | 1               |
-| [Advanced JavaScript](./advanced-javascript/)                                   | 4               |
-| [Databases](./databases/)                                                       | 2               |
-| [Node.js](node/)                                                                | 2               |
-| [Advanced Team Processes](../../shared-modules/advanced-team-processes/)        | 1               |
-| [Specialist Career Training)](../../shared-modules/specialist-career-training/) | 3 (2 in person) |
-| [Final project](./final-project/)                                               | 5               |
+| [Collaboration via GitHub](../../shared-modules/collaboration-via-github/README.md)      | 1               |
+| [Using AI in Development](../../shared-modules/using-ai-in-development/README.md)         | 1               |
+| [Advanced JavaScript](./advanced-javascript/README.md)                                   | 4               |
+| [Databases](./databases/README.md)                                                       | 2               |
+| [Node.js](node/README.md)                                                                | 2               |
+| [Advanced Team Processes](../../shared-modules/advanced-team-processes/README.md)        | 1               |
+| [Specialist Career Training)](../../shared-modules/specialist-career-training/README.md) | 3 (2 in person) |
+| [Final project](./final-project/README.md)                                               | 5               |
 
 Current total: 18 weeks

--- a/courses/foundation/README.md
+++ b/courses/foundation/README.md
@@ -6,16 +6,16 @@ Here you'll learn the fundamentals for how the web works, the basics of programm
 
 | Name                                            | Weeks           |
 | ----------------------------------------------- | --------------- |
-| [HTML & CSS](./html-and-css/)                   | 1               |
+| [HTML & CSS](./html-and-css/README.md)                   | 1               |
 | [Git](./git)                                    | 1               |
-| [Intro to Using AI](./intro-to-using-ai)        | 1               |
-| [Intro to JavaScript](./intro-to-javascript/)   | 4               |
-| [Web Architecture 101](./web-architecture-101/) | 1               |
-| [Databases](./databases/)                       | 1               |
-| [Intro to Backend](./intro-to-backend/)         | 1               |
-| [Intro to Frontend](./intro-to-frontend/)       | 1               |
-| [Team Processes Intro](./team-processes-intro)  | 1               |
-| [Career Training](./career-training/)           | 3 (1 in person) |
-| [Final project](./final-project/)               | 3               |
+| [Intro to Using AI](./intro-to-using-ai/README.md)        | 1               |
+| [Intro to JavaScript](./intro-to-javascript/README.md)   | 4               |
+| [Web Architecture 101](./web-architecture-101/README.md) | 1               |
+| [Databases](./databases/README.md)                       | 1               |
+| [Intro to Backend](./intro-to-backend/README.md)         | 1               |
+| [Intro to Frontend](./intro-to-frontend/README.md)       | 1               |
+| [Team Processes Intro](./team-processes-intro/README.md)  | 1               |
+| [Career Training](./career-training/README.md)           | 3 (1 in person) |
+| [Final project](./final-project/README.md)               | 3               |
 
 Total weeks: 16

--- a/courses/foundation/README.md
+++ b/courses/foundation/README.md
@@ -4,17 +4,17 @@ Here you'll learn the fundamentals for how the web works, the basics of programm
 
 ## Modules
 
-| Name                                            | Weeks           |
-| ----------------------------------------------- | --------------- |
+| Name                                                     | Weeks           |
+| -------------------------------------------------------- | --------------- |
 | [HTML & CSS](./html-and-css/README.md)                   | 1               |
-| [Git](./git)                                    | 1               |
-| [Intro to Using AI](./intro-to-using-ai/README.md)        | 1               |
+| [Git](./git)                                             | 1               |
+| [Intro to Using AI](./intro-to-using-ai/README.md)       | 1               |
 | [Intro to JavaScript](./intro-to-javascript/README.md)   | 4               |
 | [Web Architecture 101](./web-architecture-101/README.md) | 1               |
 | [Databases](./databases/README.md)                       | 1               |
 | [Intro to Backend](./intro-to-backend/README.md)         | 1               |
 | [Intro to Frontend](./intro-to-frontend/README.md)       | 1               |
-| [Team Processes Intro](./team-processes-intro/README.md)  | 1               |
+| [Team Processes Intro](./team-processes-intro/README.md) | 1               |
 | [Career Training](./career-training/README.md)           | 3 (1 in person) |
 | [Final project](./final-project/README.md)               | 3               |
 

--- a/courses/frontend/README.md
+++ b/courses/frontend/README.md
@@ -6,12 +6,12 @@ This specialism course is focused on setting you up to land a Frontend Developer
 
 | Name                                                                            | Weeks           |
 | ------------------------------------------------------------------------------- | --------------- |
-| [Collaboration via GitHub](../../shared-modules/collaboration-via-github/)      | 1               |
-| [Using AI in Development](../../shared-modules/using-ai-in-development)         | 1               |
-| [Advanced JavaScript](./advanced-javascript/)                                   | 4               |
-| [React](./react/)                                                               | 5               |
-| [Advanced Team Processes](../../shared-modules/advanced-team-processes/)        | 1               |
-| [Specialist Career Training)](../../shared-modules/specialist-career-training/) | 3 (2 in person) |
-| [Final project](./final-project/)                                               | 5               |
+| [Collaboration via GitHub](../../shared-modules/collaboration-via-github/README.md)      | 1               |
+| [Using AI in Development](../../shared-modules/using-ai-in-development/README.md)         | 1               |
+| [Advanced JavaScript](./advanced-javascript/README.md)                                   | 4               |
+| [React](./react/README.md)                                                               | 5               |
+| [Advanced Team Processes](../../shared-modules/advanced-team-processes/README.md)        | 1               |
+| [Specialist Career Training)](../../shared-modules/specialist-career-training/README.md) | 3 (2 in person) |
+| [Final project](./final-project/README.md)                                               | 5               |
 
 Total week: 19 weeks

--- a/courses/frontend/README.md
+++ b/courses/frontend/README.md
@@ -4,10 +4,10 @@ This specialism course is focused on setting you up to land a Frontend Developer
 
 ## Modules
 
-| Name                                                                            | Weeks           |
-| ------------------------------------------------------------------------------- | --------------- |
+| Name                                                                                     | Weeks           |
+| ---------------------------------------------------------------------------------------- | --------------- |
 | [Collaboration via GitHub](../../shared-modules/collaboration-via-github/README.md)      | 1               |
-| [Using AI in Development](../../shared-modules/using-ai-in-development/README.md)         | 1               |
+| [Using AI in Development](../../shared-modules/using-ai-in-development/README.md)        | 1               |
 | [Advanced JavaScript](./advanced-javascript/README.md)                                   | 4               |
 | [React](./react/README.md)                                                               | 5               |
 | [Advanced Team Processes](../../shared-modules/advanced-team-processes/README.md)        | 1               |

--- a/courses/pre-course/README.md
+++ b/courses/pre-course/README.md
@@ -4,6 +4,6 @@ The Pre-Course is a collection of modules that you should complete before joinin
 
 ## Modules
 
-### [Technical Application](./Technical-Application/README.md)
+### [Technical Application](./technical-application/README.md)
 
-### [Self Study](./Self-Study/README.md)
+### [Self Study](./self-study/README.md)

--- a/shared-modules/README.md
+++ b/shared-modules/README.md
@@ -2,9 +2,9 @@
 
 Some modules are taught across multiple courses, when the content does not change depending on the e.g specialism. Those modules live in this directory, and can be referenced to in the course's module list.
 
-| Name                                                                            | 
-| ------------------------------------------------------------------------------- |
-| [Collaboration via GitHub](./collaboration-via-github/README.md)      | 
-| [Collaboration via GitHub](./advanced-team-processes/README.md)      | 
-| [Collaboration via GitHub](./specialist-career-training/README.md)      | 
-| [Collaboration via GitHub](./using-ai-in-development/README.md)      | 
+| Name                                                               |
+| ------------------------------------------------------------------ |
+| [Collaboration via GitHub](./collaboration-via-github/README.md)   |
+| [Collaboration via GitHub](./advanced-team-processes/README.md)    |
+| [Collaboration via GitHub](./specialist-career-training/README.md) |
+| [Collaboration via GitHub](./using-ai-in-development/README.md)    |

--- a/shared-modules/README.md
+++ b/shared-modules/README.md
@@ -5,6 +5,6 @@ Some modules are taught across multiple courses, when the content does not chang
 | Name                                                               |
 | ------------------------------------------------------------------ |
 | [Collaboration via GitHub](./collaboration-via-github/README.md)   |
-| [Collaboration via GitHub](./advanced-team-processes/README.md)    |
-| [Collaboration via GitHub](./specialist-career-training/README.md) |
-| [Collaboration via GitHub](./using-ai-in-development/README.md)    |
+| [Advanced Team Processes](./advanced-team-processes/README.md)    |
+| [Specialist Career Training](./specialist-career-training/README.md) |
+| [Using AI in Development](./using-ai-in-development/README.md)    |

--- a/shared-modules/README.md
+++ b/shared-modules/README.md
@@ -1,3 +1,10 @@
-# Shared modules
+# Shared Modules
 
-If a module is to be re-used across different courses, they can live in here.
+Some modules are taught across multiple courses, when the content does not change depending on the e.g specialism. Those modules live in this directory, and can be referenced to in the course's module list.
+
+| Name                                                                            | 
+| ------------------------------------------------------------------------------- |
+| [Collaboration via GitHub](./collaboration-via-github/README.md)      | 
+| [Collaboration via GitHub](./advanced-team-processes/README.md)      | 
+| [Collaboration via GitHub](./specialist-career-training/README.md)      | 
+| [Collaboration via GitHub](./using-ai-in-development/README.md)      | 

--- a/shared-modules/README.md
+++ b/shared-modules/README.md
@@ -2,9 +2,9 @@
 
 Some modules are taught across multiple courses, when the content does not change depending on the e.g specialism. Those modules live in this directory, and can be referenced to in the course's module list.
 
-| Name                                                               |
-| ------------------------------------------------------------------ |
-| [Collaboration via GitHub](./collaboration-via-github/README.md)   |
-| [Advanced Team Processes](./advanced-team-processes/README.md)    |
+| Name                                                                 |
+| -------------------------------------------------------------------- |
+| [Collaboration via GitHub](./collaboration-via-github/README.md)     |
+| [Advanced Team Processes](./advanced-team-processes/README.md)       |
 | [Specialist Career Training](./specialist-career-training/README.md) |
-| [Using AI in Development](./using-ai-in-development/README.md)    |
+| [Using AI in Development](./using-ai-in-development/README.md)       |


### PR DESCRIPTION
To make navigation more user friendly, we should link to the README's of courses and modules directly, so they appear in full when viewing in GitHub (rather than seeing a list of files and directories at the top of the page).