### PR TITLE
Test absolute links

### DIFF
--- a/courses/frontend/README.md
+++ b/courses/frontend/README.md
@@ -4,14 +4,14 @@ This specialism course is focused on setting you up to land a Frontend Developer
 
 ## Modules
 
-| Name                                                                                    | Weeks           |
-| --------------------------------------------------------------------------------------- | --------------- |
+| Name                                                                               | Weeks           |
+| ---------------------------------------------------------------------------------- | --------------- |
 | [Collaboration via GitHub](/shared-modules/collaboration-via-github/README.md)     | 1               |
 | [Using AI in Development](/shared-modules/using-ai-in-development/README.md)       | 1               |
-| [Advanced JavaScript](./advanced-javascript/README.md)                                  | 4               |
-| [React](./react/README.md)                                                              | 5               |
+| [Advanced JavaScript](./advanced-javascript/README.md)                             | 4               |
+| [React](./react/README.md)                                                         | 5               |
 | [Advanced Team Processes](/shared-modules/advanced-team-processes/README.md)       | 1               |
 | [Specialist Career Training](/shared-modules/specialist-career-training/README.md) | 3 (2 in person) |
-| [Final project](./final-project/README.md)                                              | 5               |
+| [Final project](./final-project/README.md)                                         | 5               |
 
 Total: 19 weeks

--- a/courses/frontend/README.md
+++ b/courses/frontend/README.md
@@ -6,12 +6,12 @@ This specialism course is focused on setting you up to land a Frontend Developer
 
 | Name                                                                                    | Weeks           |
 | --------------------------------------------------------------------------------------- | --------------- |
-| [Collaboration via GitHub](../../shared-modules/collaboration-via-github/README.md)     | 1               |
-| [Using AI in Development](../../shared-modules/using-ai-in-development/README.md)       | 1               |
+| [Collaboration via GitHub](/shared-modules/collaboration-via-github/README.md)     | 1               |
+| [Using AI in Development](/shared-modules/using-ai-in-development/README.md)       | 1               |
 | [Advanced JavaScript](./advanced-javascript/README.md)                                  | 4               |
 | [React](./react/README.md)                                                              | 5               |
-| [Advanced Team Processes](../../shared-modules/advanced-team-processes/README.md)       | 1               |
-| [Specialist Career Training](../../shared-modules/specialist-career-training/README.md) | 3 (2 in person) |
+| [Advanced Team Processes](/shared-modules/advanced-team-processes/README.md)       | 1               |
+| [Specialist Career Training](/shared-modules/specialist-career-training/README.md) | 3 (2 in person) |
 | [Final project](./final-project/README.md)                                              | 5               |
 
 Total: 19 weeks


### PR DESCRIPTION
For some reason the links in the specialism courses are showing up as external (linking to github) when they should go localy. Debugging here and trying absolute links to see if that helps.